### PR TITLE
Revision to get_var in resource pools

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -67,5 +67,5 @@ pub trait LLVMApi {
     /// --- VARIABLES --- ///
     fn init_var(&mut self, builder: BuilderTag, var_name: &str, data_type: TypeTag, initial_value: Option<ValueTag>) -> Option<ValueTag>;
     fn reassign_var(&mut self, builder: BuilderTag, variable_alloc: ValueTag, new_value: ValueTag) -> Option<()>;
-    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag) -> Option<ValueTag>;
+    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag, temp_name: &str) -> Option<ValueTag>;
 }

--- a/src/ir/router.rs
+++ b/src/ir/router.rs
@@ -215,7 +215,7 @@ impl LLVMApi for SafeLLVM {
         self.pools.reassign_var(builder, variable_alloc, new_value)
     }
 
-    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag) -> Option<ValueTag> {
-        self.pools.get_var(builder, variable_type, variable_alloc)
+    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag, temp_name: &str) -> Option<ValueTag> {
+        self.pools.get_var(builder, variable_type, variable_alloc, temp_name)
     }
 }

--- a/src/ir/var.rs
+++ b/src/ir/var.rs
@@ -120,13 +120,14 @@ impl ResourcePools {
         &mut self,
         builder_tag: BuilderTag, 
         variable_type_tag: TypeTag, 
-        variable_alloc_tag: ValueTag
+        variable_alloc_tag: ValueTag,
+        temp_name: &str
     ) -> Option<ValueTag> {
         let builder_arc_rwlock = self.get_builder(builder_tag)?;
         let variable_type_arc_rwlock = self.get_type(variable_type_tag)?;
         let variable_alloc_arc_rwlock = self.get_value(variable_alloc_tag)?;
 
-        let tmp_load_cstr = CString::new("tmpload").expect("Failed to create CString for tmpload");
+        let tmp_load_cstr = CString::new(temp_name).expect("Failed to create CString for tmpload");
 
         let raw_ptr = unsafe {
             let builder_ptr = builder_arc_rwlock.read().expect("Failed to lock builder for reading").read(LLVMRefType::Builder, |builder_ref| {

--- a/src/router.rs
+++ b/src/router.rs
@@ -219,7 +219,7 @@ impl LLVMApi for SafeLLVM {
         self.ir_codegen_impl.reassign_var(builder, variable_alloc, new_value)
     }
 
-    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag) -> Option<ValueTag> {
-        self.ir_codegen_impl.get_var(builder, variable_type, variable_alloc)
+    fn get_var(&mut self, builder: BuilderTag, variable_type: TypeTag, variable_alloc: ValueTag, temp_name: &str) -> Option<ValueTag> {
+        self.ir_codegen_impl.get_var(builder, variable_type, variable_alloc, temp_name)
     }
 }

--- a/tests/ir_tests/var_tests.rs
+++ b/tests/ir_tests/var_tests.rs
@@ -40,7 +40,7 @@ fn test_reassign_var() {
     let new_value_tag = resource_pools.create_integer(context_tag, 100).expect("Failed to create new value");
     resource_pools.reassign_var(builder_tag, var_tag, new_value_tag).expect("Variable reassignment failed");
 
-    assert!(resource_pools.get_var(builder_tag, int_type_tag, var_tag).is_some(), "Variable should be reassigned successfully");
+    assert!(resource_pools.get_var(builder_tag, int_type_tag, var_tag, "tmp").is_some(), "Variable should be reassigned successfully");
 }
 
 
@@ -60,7 +60,7 @@ fn test_get_var() {
     resource_pools.position_builder(builder_tag, block_tag).expect("Failed to position builder");
 
     let var_tag = resource_pools.init_var(builder_tag, "myVar", int_type_tag, Some(initial_value_tag)).expect("Variable should be initialized successfully");
-    let retrieved_var_tag = resource_pools.get_var(builder_tag, int_type_tag, var_tag);
+    let retrieved_var_tag = resource_pools.get_var(builder_tag, int_type_tag, var_tag, "tmp");
 
     assert!(retrieved_var_tag.is_some(), "Variable should be retrieved successfully");
 }


### PR DESCRIPTION
Previously the temporary variable name was hard coded, which would cause issues if many variables needed to be loaded at once. This simple change allows for a string slice to be passed in which will change this name so we can assure that this issue won't happen.